### PR TITLE
Move print statements to logs (Resolves #5)

### DIFF
--- a/example/lib/demo_orbiting_circles.dart
+++ b/example/lib/demo_orbiting_circles.dart
@@ -3,6 +3,8 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:follow_the_leader/follow_the_leader.dart';
 
+import 'logging.dart';
+
 class OrbitingCirclesDemo extends StatefulWidget {
   const OrbitingCirclesDemo({Key? key}) : super(key: key);
 
@@ -29,7 +31,7 @@ class _OrbitingCirclesDemoState extends State<OrbitingCirclesDemo> {
 
   @override
   Widget build(BuildContext context) {
-    print("Rebuilding entire demo");
+    appLog.fine("Rebuilding entire demo");
     return SizedBox(
       key: _screenBoundKey,
       child: Stack(

--- a/example/lib/logging.dart
+++ b/example/lib/logging.dart
@@ -1,0 +1,3 @@
+import 'package:logging/logging.dart';
+
+final appLog = Logger("FollowTheLeaderDemo");

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,11 +1,18 @@
 import 'package:example/demo_boucing_ball.dart';
 import 'package:example/ios_popover/demo_toolbar.dart';
+import 'package:example/logging.dart';
 import 'package:flutter/material.dart';
+import 'package:follow_the_leader/follow_the_leader.dart';
+import 'package:logging/logging.dart';
 
 import 'demo_orbiting_circles.dart';
 import 'ios_popover/demo_popover.dart';
 
 void main() {
+  FollowTheLeaderLogs.initLoggers(Level.FINEST, {
+    followerLog,
+    appLog,
+  });
   runApp(const MyApp());
 }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,49 +5,56 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.10.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      url: "https://pub.dartlang.org"
+      sha256: e35129dc44c9118cee2a5603506d823bab99c68393879edb440e0090d07586be
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   flutter:
@@ -59,7 +66,8 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   flutter_test:
@@ -78,42 +86,64 @@ packages:
     dependency: "direct dev"
     description:
       name: golden_toolkit
-      url: "https://pub.dartlang.org"
+      sha256: "111e913c99632d470fed8263900d64fd75ec1ca2997702e0b2c05f63649d5440"
+      url: "https://pub.dev"
     source: hosted
     version: "0.11.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.5"
   lints:
     dependency: transitive
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
+  logging:
+    dependency: "direct main"
+    description:
+      name: logging
+      sha256: c0bbfe94d46aedf9b8b3e695cf3bd48c8e14b35e3b2c639e0aa7755d589ba946
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.2"
   sky_engine:
@@ -125,50 +155,57 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "862015c5db1f3f3c4ea3b94dc2490363a84262994b88902315ed74be1155612f"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: c9aba3b3dbfe8878845dfab5fa096eb8de7b62231baeeb1cea8e3ee81ca8c6d8
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.15"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
 sdks:
-  dart: ">=2.17.6 <3.0.0"
+  dart: ">=2.18.0 <4.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
+  logging: ^1.0.1
 
   follow_the_leader:
     path: ../

--- a/lib/follow_the_leader.dart
+++ b/lib/follow_the_leader.dart
@@ -4,3 +4,4 @@ export 'src/follower.dart';
 export 'src/follower_the_leader.dart';
 export 'src/layer_link.dart';
 export 'src/leader.dart';
+export 'src/logging.dart';

--- a/lib/src/follower.dart
+++ b/lib/src/follower.dart
@@ -3,6 +3,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
+import 'package:follow_the_leader/follow_the_leader.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 import 'layer_link.dart';
@@ -131,7 +132,7 @@ class RenderFollowerLayer extends RenderProxyBox {
   CustomLayerLink _link;
   set link(CustomLayerLink value) {
     if (_link == value) return;
-    print("Setting new link");
+    followerLog.fine("Setting new link");
     _link = value;
     markNeedsPaint();
   }
@@ -142,7 +143,7 @@ class RenderFollowerLayer extends RenderProxyBox {
     if (newKey == _boundaryKey) {
       return;
     }
-    print("Setting new boundaryKey");
+    followerLog.fine("Setting new boundaryKey");
     _boundaryKey = newKey;
     markNeedsPaint();
   }
@@ -170,7 +171,7 @@ class RenderFollowerLayer extends RenderProxyBox {
   Offset _offset;
   set offset(Offset value) {
     if (_offset == value) return;
-    print("Setting new follower offset");
+    followerLog.fine("Setting new follower offset");
     _offset = value;
     markNeedsPaint();
   }
@@ -255,15 +256,15 @@ class RenderFollowerLayer extends RenderProxyBox {
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    print("Painting composited follower: $offset");
+    followerLog.fine("Painting composited follower: $offset");
 
     if (!link.leaderConnected && _previousFollowerOffset == null) {
-      print("The leader isn't connected and there's no cached offset. Not painting anything.");
+      followerLog.fine("The leader isn't connected and there's no cached offset. Not painting anything.");
       return;
     }
 
     if (link.leaderConnected) {
-      print("The leader isn't connect. Using previous offset.");
+      followerLog.fine("The leader isn't connect. Using previous offset.");
       _calculateFollowerOffset();
     }
 
@@ -285,7 +286,7 @@ class RenderFollowerLayer extends RenderProxyBox {
     context.pushLayer(
       layer!,
       (context, offset) {
-        print("Painting follower content. Incoming offset: $offset");
+        followerLog.fine("Painting follower content. Incoming offset: $offset");
         super.paint(context, offset);
       },
       Offset.zero,
@@ -310,10 +311,10 @@ class RenderFollowerLayer extends RenderProxyBox {
 
     final Offset effectiveLinkedOffset =
         leaderSize == null ? offset : leaderAnchor.alongSize(leaderSize) - followerAnchor.alongSize(size) + offset;
-    print("Leader layer offset: ${link.leader!.offset}");
+    followerLog.fine("Leader layer offset: ${link.leader!.offset}");
     final boundaryBox = boundaryKey!.currentContext!.findRenderObject() as RenderBox;
-    print("Boundary box size: ${boundaryBox.size}");
-    print("Follower box size: $size");
+    followerLog.fine("Boundary box size: ${boundaryBox.size}");
+    followerLog.fine("Follower box size: $size");
     // final boundaryOffset = boundaryBox.globalToLocal(localToGlobal(Offset.zero));
     final boundaryOffset = link.leader!.offset + effectiveLinkedOffset;
     final xAdjustment = boundaryOffset.dx < 0
@@ -327,7 +328,7 @@ class RenderFollowerLayer extends RenderProxyBox {
             ? (boundaryBox.size.height - size.height) - boundaryOffset.dy
             : 0.0;
     final adjustment = Offset(xAdjustment, yAdjustment);
-    print("Adjustment: $adjustment");
+    followerLog.fine("Adjustment: $adjustment");
 
     _previousFollowerOffset = effectiveLinkedOffset + adjustment;
   }

--- a/lib/src/logging.dart
+++ b/lib/src/logging.dart
@@ -1,0 +1,71 @@
+// ignore_for_file: avoid_print
+
+import 'package:logging/logging.dart' as logging;
+
+final _activeLoggers = <logging.Logger>{};
+
+/// Defines the names used for the loggers.
+class LogNames {
+  static const leader = 'leader';
+  static const follower = 'follower';
+}
+
+final leaderLog = logging.Logger(LogNames.leader);
+final followerLog = logging.Logger(LogNames.follower);
+
+class FollowTheLeaderLogs {
+  /// Initialize the given [loggers] using the minimum [level].
+  ///
+  /// To enable all the loggers, use [FollowTheLeaderLogs.initAllLogs].
+  static void initLoggers(logging.Level level, Set<logging.Logger> loggers) {
+    logging.hierarchicalLoggingEnabled = true;
+
+    for (final logger in loggers) {
+      if (!_activeLoggers.contains(logger)) {
+        print('Initializing logger: ${logger.name}');
+        logger
+          ..level = level
+          ..onRecord.listen(_printLog);
+
+        _activeLoggers.add(logger);
+      }
+    }
+  }
+
+  /// Initializes all the available loggers.
+  ///
+  /// To control which loggers are initialized, use [FollowTheLeaderLogs.initLoggers].
+  static void initAllLogs(logging.Level level) {
+    initLoggers(level, {logging.Logger.root});
+  }
+
+  /// Returns `true` if the given [logger] is currently logging, or
+  /// `false` otherwise.
+  ///
+  /// Generally, developers should call loggers, regardless of whether
+  /// a given logger is active. However, sometimes you may want to log
+  /// information that's costly to compute. In such a case, you can
+  /// choose to compute the expensive information only if the given
+  /// logger will actually log the information.
+  static bool isLogActive(logging.Logger logger) {
+    return _activeLoggers.contains(logger);
+  }
+
+  /// Deactivates the given [loggers].
+  static void deactivateLoggers(Set<logging.Logger> loggers) {
+    for (final logger in loggers) {
+      if (_activeLoggers.contains(logger)) {
+        print('Deactivating logger: ${logger.name}');
+        logger.clearListeners();
+
+        _activeLoggers.remove(logger);
+      }
+    }
+  }
+
+  /// Logs a record using a print statement.
+  static void _printLog(logging.LogRecord record) {
+    print(
+        '(${record.time.second}.${record.time.millisecond.toString().padLeft(3, '0')}) ${record.loggerName} > ${record.level.name}: ${record.message}');
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,51 +5,50 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.8.2"
+    version: "2.10.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -59,7 +58,8 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: b543301ad291598523947dc534aaddc5aaad597b709d2426d3a0e0d44c5cb493
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   flutter_test:
@@ -67,41 +67,62 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.5"
   lints:
     dependency: transitive
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: a2c3d198cb5ea2e179926622d433331d8b58374ab8f29cdda6e863bd62fd369c
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  logging:
+    dependency: "direct main"
+    description:
+      name: logging
+      sha256: c0bbfe94d46aedf9b8b3e695cf3bd48c8e14b35e3b2c639e0aa7755d589ba946
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.4"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -111,50 +132,57 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "862015c5db1f3f3c4ea3b94dc2490363a84262994b88902315ed74be1155612f"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: c9aba3b3dbfe8878845dfab5fa096eb8de7b62231baeeb1cea8e3ee81ca8c6d8
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.15"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
+  dart: ">=2.18.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  logging: ^1.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Move print statements to logs. Resolves #5 

Currently, we use print statements to display logs.

This PR changes the print statements to use loggers, similar to `super_editor`.