### PR TITLE
Point at Leader automatically, and repaint Follower child when Leader moves (Resolves #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ Follower.withOffset(
 
 `Follower`'s can position themselves with a constant distance from a `Leader` using `.withOffset()`,
 as shown above. Or, `Follower`'s can choose their exact location on every frame by using
-`.withDynamics()`.
+`.withAligner()`.
 
 ```dart
 // Follower appears where the aligner says it should.
-Follower.withOffset(
+Follower.withAligner(
   link: _leaderLink,
   aligner: _aligner,
   child: YourFollowerWidget(),
@@ -49,7 +49,7 @@ To constrain where your `Follower` is allowed to appear, pass a `boundary` to yo
 
 ```dart
 // Follower is constrained by the given boundary.
-Follower.withOffset(
+Follower.withAligner(
   link: _leaderLink,
   aligner: _aligner,
   boundary: _boundary,

--- a/example/lib/demo_kitchen_sink.dart
+++ b/example/lib/demo_kitchen_sink.dart
@@ -29,7 +29,7 @@ class _KitchenSinkDemoState extends State<KitchenSinkDemo> {
 
   void _onPanUpdate(DragUpdateDetails details) {
     _pinOffset.value = _pinOffset.value! + details.delta;
-    _globalMenuFocalPoint.value = (context.findRenderObject() as RenderBox).localToGlobal(_pinOffset.value!);
+    // _globalMenuFocalPoint.value = (context.findRenderObject() as RenderBox).localToGlobal(_pinOffset.value!);
   }
 
   void _onNoLimitsTap() {
@@ -189,13 +189,15 @@ class _KitchenSinkDemoState extends State<KitchenSinkDemo> {
         leaderAnchor: _followerDirection.leaderAlignment,
         followerAnchor: _followerDirection.followerAlignment,
         boundary: _boundary,
+        repaintWhenLeaderChanges: true,
         child: menu,
       );
     } else {
-      return Follower.withDynamics(
+      return Follower.withAligner(
         link: _pinLink,
-        boundary: _boundary,
         aligner: _aligner,
+        boundary: _boundary,
+        repaintWhenLeaderChanges: true,
         child: menu,
       );
     }
@@ -210,44 +212,36 @@ class _KitchenSinkDemoState extends State<KitchenSinkDemo> {
           color: Colors.red,
         );
       case _MenuType.iOSToolbar:
-        return AnimatedBuilder(
-          animation: _globalMenuFocalPoint,
-          builder: (context, value) {
-            final isContentVisible = _boundary == null || _boundary!.contains(_globalMenuFocalPoint.value!);
-
-            return AnimatedOpacity(
-              opacity: isContentVisible ? 1.0 : 0.0,
-              duration: const Duration(milliseconds: 250),
-              child: CupertinoPopoverToolbar(
-                globalFocalPoint: _globalMenuFocalPoint.value ?? Offset.zero,
-                children: _toolbarMenuItems,
-              ),
-            );
-          },
+        return FollowerFadeOutBeyondBoundary(
+          link: _pinLink,
+          boundary: _boundary,
+          child: CupertinoPopoverToolbar(
+            focalPoint: LeaderMenuFocalPoint(link: _pinLink),
+            children: _toolbarMenuItems,
+          ),
         );
       case _MenuType.iOSMenu:
-        return AnimatedBuilder(
-          animation: _globalMenuFocalPoint,
-          builder: (context, value) {
-            return CupertinoPopoverMenu(
-              globalFocalPoint: _globalMenuFocalPoint.value ?? Offset.zero,
-              padding: const EdgeInsets.all(12.0),
-              child: const SizedBox(
-                width: 100,
-                height: 54,
-                child: Center(
-                  child: Text(
-                    'Popover Content',
-                    textAlign: TextAlign.center,
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontSize: 20,
-                    ),
+        return FollowerFadeOutBeyondBoundary(
+          link: _pinLink,
+          boundary: _boundary,
+          child: CupertinoPopoverMenu(
+            focalPoint: LeaderMenuFocalPoint(link: _pinLink),
+            padding: const EdgeInsets.all(12.0),
+            child: const SizedBox(
+              width: 100,
+              height: 54,
+              child: Center(
+                child: Text(
+                  'Popover Content',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 20,
                   ),
                 ),
               ),
-            );
-          },
+            ),
+          ),
         );
     }
   }

--- a/example/lib/demo_kitchen_sink.dart
+++ b/example/lib/demo_kitchen_sink.dart
@@ -18,7 +18,6 @@ class _KitchenSinkDemoState extends State<KitchenSinkDemo> {
   final _pinLink = LeaderLink();
 
   final _pinOffset = ValueNotifier<Offset?>(null);
-  final _globalMenuFocalPoint = ValueNotifier<Offset?>(null);
   _FollowerDirection _followerDirection = _FollowerDirection.up;
   _FollowerConstraint _followerConstraints = _FollowerConstraint.none;
   _MenuType _menuType = _MenuType.smallPopover;
@@ -29,7 +28,6 @@ class _KitchenSinkDemoState extends State<KitchenSinkDemo> {
 
   void _onPanUpdate(DragUpdateDetails details) {
     _pinOffset.value = _pinOffset.value! + details.delta;
-    // _globalMenuFocalPoint.value = (context.findRenderObject() as RenderBox).localToGlobal(_pinOffset.value!);
   }
 
   void _onNoLimitsTap() {
@@ -104,7 +102,6 @@ class _KitchenSinkDemoState extends State<KitchenSinkDemo> {
       WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
         setState(() {
           _pinOffset.value = (context.findRenderObject() as RenderBox).size.center(Offset.zero);
-          _globalMenuFocalPoint.value = (context.findRenderObject() as RenderBox).localToGlobal(_pinOffset.value!);
         });
       });
     }

--- a/example/lib/infrastructure/ball_sandbox.dart
+++ b/example/lib/infrastructure/ball_sandbox.dart
@@ -270,7 +270,7 @@ class _BallSandboxState extends State<BallSandbox> {
     return Positioned(
       left: 0,
       top: 0,
-      child: Follower.withDynamics(
+      child: Follower.withAligner(
         key: widget.followerKey,
         link: _leaderLink,
         aligner: widget.followerAligner,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -8,7 +8,7 @@ import 'demo_orbiting_circles.dart';
 
 void main() {
   FtlLogs.initLoggers(Level.FINEST, {
-    // FtlLogs.follower,
+    FtlLogs.follower,
     // appLog,
   });
   runApp(const MyApp());

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,56 +5,49 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.10.0"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: e35129dc44c9118cee2a5603506d823bab99c68393879edb440e0090d07586be
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.5"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.1"
   flutter:
@@ -66,8 +59,7 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
   flutter_test:
@@ -81,69 +73,55 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.0.2"
   golden_toolkit:
     dependency: "direct dev"
     description:
       name: golden_toolkit
-      sha256: "111e913c99632d470fed8263900d64fd75ec1ca2997702e0b2c05f63649d5440"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.11.0"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.5"
   lints:
     dependency: transitive
     description:
       name: lints
-      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
   logging:
     dependency: "direct main"
     description:
       name: logging
-      sha256: c0bbfe94d46aedf9b8b3e695cf3bd48c8e14b35e3b2c639e0aa7755d589ba946
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
   overlord:
     dependency: "direct main"
     description:
       path: "."
-      ref: getting-to-work-with-follow-the-leader
-      resolved-ref: "2babd0defe091c7ac5f231e8f52240ef13d0da4e"
+      ref: "2_dynamic-menu-focal-point"
+      resolved-ref: ea95fe96b0f8ef7b48ccd76c6746e66c672d4c18
       url: "git@github.com:Flutter-Bounty-Hunters/overlord.git"
     source: git
     version: "0.0.1"
@@ -151,8 +129,7 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.2"
   sky_engine:
@@ -164,58 +141,51 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.11.0"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "862015c5db1f3f3c4ea3b94dc2490363a84262994b88902315ed74be1155612f"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: c9aba3b3dbfe8878845dfab5fa096eb8de7b62231baeeb1cea8e3ee81ca8c6d8
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.15"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.19.0-374.1.beta <4.0.0"
+  dart: ">=2.18.0 <3.0.0"
   flutter: ">=1.17.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -120,8 +120,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "2_dynamic-menu-focal-point"
-      resolved-ref: ea95fe96b0f8ef7b48ccd76c6746e66c672d4c18
+      ref: main
+      resolved-ref: "79afc1b61fa1c64cda7c4b93cd93d0b75c31b8ee"
       url: "git@github.com:Flutter-Bounty-Hunters/overlord.git"
     source: git
     version: "0.0.1"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -36,13 +36,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.16.0"
-  cupertino_icons:
-    dependency: "direct main"
-    description:
-      name: cupertino_icons
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.5"
   fake_async:
     dependency: transitive
     description:
@@ -187,5 +180,4 @@ packages:
     source: hosted
     version: "2.1.2"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
-  flutter: ">=1.17.0"
+  dart: ">=2.17.6 <3.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   overlord:
     git:
       url: git@github.com:Flutter-Bounty-Hunters/overlord.git
-      ref: 2_dynamic-menu-focal-point
+      ref: main
 
 dependency_overrides:
   follow_the_leader:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   overlord:
     git:
       url: git@github.com:Flutter-Bounty-Hunters/overlord.git
-      ref: getting-to-work-with-follow-the-leader
+      ref: 2_dynamic-menu-focal-point
 
 dependency_overrides:
   follow_the_leader:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -30,24 +30,22 @@ dependencies:
   flutter:
     sdk: flutter
 
-
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.2
   logging: ^1.0.1
 
   follow_the_leader:
     git:
       url: git@github.com:Flutter-Bounty-Hunters/follow_the_leader.git
 
-  overlord:
-    git:
-      url: git@github.com:Flutter-Bounty-Hunters/overlord.git
-      ref: main
+  overlord: ^0.0.1
 
 dependency_overrides:
   follow_the_leader:
     path: ../
+
+  overlord:
+    git:
+      url: git@github.com:Flutter-Bounty-Hunters/overlord.git
+      ref: main
 
 dev_dependencies:
   flutter_test:

--- a/lib/follow_the_leader.dart
+++ b/lib/follow_the_leader.dart
@@ -2,6 +2,7 @@ library follow_the_leader;
 
 export 'src/build_in_order.dart';
 export 'src/follower.dart';
+export 'src/follower_extensions.dart';
 export 'src/leader_link.dart';
 export 'src/leader.dart';
 export 'src/logging.dart';

--- a/lib/src/follower_extensions.dart
+++ b/lib/src/follower_extensions.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/widgets.dart';
+import 'package:follow_the_leader/follow_the_leader.dart';
+
+/// A `Widget` that fades out when the [Leader] attached to the given [link]
+/// exceeds the given [boundary].
+///
+/// For example, if the [boundary] represents the screen size, then when the
+/// associated [Leader] widget moves outside the screen boundary, this widget
+/// fades out. When the [Leader] re-enters the visible screen area, this
+/// widget fades in.
+class FollowerFadeOutBeyondBoundary extends StatelessWidget {
+  const FollowerFadeOutBeyondBoundary({
+    Key? key,
+    required this.link,
+    this.boundary,
+    this.duration = const Duration(milliseconds: 250),
+    this.curve = Curves.linear,
+    required this.child,
+  }) : super(key: key);
+
+  /// A [LeaderLink] that's attached to a [Leader] widget, whose offset
+  /// determines whether this widget should be visible.
+  final LeaderLink link;
+
+  /// A [FollowerBoundary], which is combined with the [link] [Leader]'s
+  /// offset, to determine whether this widget should be visible.
+  final FollowerBoundary? boundary;
+
+  /// [Duration] to fade out and fade in.
+  final Duration duration;
+
+  /// The animation [Curve] applied to the fade out and fade in animations.
+  final Curve curve;
+
+  /// A [Widget] that's following a [Leader] attached to the [link].
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: link,
+      builder: (context, value) {
+        final isContentVisible = boundary == null || link.offset == null || boundary!.contains(link.offset!);
+        return AnimatedOpacity(
+          opacity: isContentVisible ? 1.0 : 0.0,
+          duration: duration,
+          curve: curve,
+          child: child,
+        );
+      },
+    );
+  }
+}

--- a/lib/src/leader.dart
+++ b/lib/src/leader.dart
@@ -214,6 +214,7 @@ class LeaderLayer extends ContainerLayer {
   @override
   void addToScene(ui.SceneBuilder builder) {
     _lastOffset = offset;
+    link.offset = offset;
     if (_lastOffset != Offset.zero) {
       engineLayer = builder.pushTransform(
         Matrix4.translationValues(_lastOffset!.dx, _lastOffset!.dy, 0.0).storage,


### PR DESCRIPTION
Point at Leader automatically, and repaint Follower child when Leader moves (Resolves #15)

Reworks the example app so that it uses `Overlords` new `LeaderMenuFocalPoint` to orient the menu arrow towards the `Leader`. The example app is no longer responsible for tracking the `Leader`'s global offset and reporting it to the popover menu.

The `LeaderLink` now notifies listeners whenever the `Leader`'s size or offset changes. `Follower` widgets now have a boolean property called `repaintWhenLeaderChanges`. When that property is `true`, the `Follower` will mark the child widget as needing to repaint whenever the `LeaderLink` changes. This change is needed because `Follower`s such as menus with arrows need to paint based on the `Leader` location, and moving the `Leader` won't necessary rebuild a `Follower`. Therefore, the `Follower` needs an opportunity to repaint outside the standard widget tree rebuild process.