### PR TITLE
Added test that ensures when a Leader comes into and out of existence, Followers don't blow up (Resolves #19)

### DIFF
--- a/test/smoke_test.dart
+++ b/test/smoke_test.dart
@@ -92,6 +92,48 @@ void main() {
 
       // Reaching this point without an error is the success condition.
     });
+
+    testWidgets("build when the Leader comes and goes", (widgetTester) async {
+      final showLeader = ValueNotifier<bool>(false);
+      final link = LeaderLink();
+
+      await _pumpScaffold(
+        widgetTester: widgetTester,
+        child: Stack(
+          children: [
+            Center(
+              child: ValueListenableBuilder(
+                  valueListenable: showLeader,
+                  builder: (context, value, child) {
+                    // Don't build the Leader. Make the Follower and orphan.
+                    if (!showLeader.value) {
+                      return const SizedBox();
+                    }
+
+                    // Build the Leader.
+                    return Leader(
+                      link: link,
+                    );
+                  }),
+            ),
+            Follower.withOffset(
+              link: link,
+              offset: const Offset(0, -50),
+            ),
+          ],
+        ),
+      );
+
+      // Switch the value to show the Leader and rebuild.
+      showLeader.value = true;
+      await widgetTester.pumpAndSettle();
+
+      // Switch the value to get rid of the Leader and rebuild.
+      showLeader.value = false;
+      await widgetTester.pumpAndSettle();
+
+      // Reaching this point without an error is the success condition.
+    });
   });
 }
 


### PR DESCRIPTION
Added test that ensures when a Leader comes into and out of existence, Followers don't blow up (Resolves #19)

It turns out that the reported problem only exists in `overlord`. There was nothing to fix in `follow_the_leader`. I added a test to ensure that `Leader`s can come and go and `Follower`s won't blow up.