### PR TITLE
Add 'scale' to LeaderLink so that clients can fully account for transform (Resolves #21)

### DIFF
--- a/example/lib/demo_scaling.dart
+++ b/example/lib/demo_scaling.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:follow_the_leader/follow_the_leader.dart';
 import 'package:overlord/follow_the_leader.dart';

--- a/example/lib/demo_scaling.dart
+++ b/example/lib/demo_scaling.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:follow_the_leader/follow_the_leader.dart';
+import 'package:overlord/follow_the_leader.dart';
+import 'package:overlord/overlord.dart';
+
+/// Demonstrates that leaders and followers paint and handle touch events
+/// as expected, when they are scaled up/down.
+class ScalingDemo extends StatefulWidget {
+  const ScalingDemo({Key? key}) : super(key: key);
+
+  @override
+  State<ScalingDemo> createState() => _ScalingDemoState();
+}
+
+class _ScalingDemoState extends State<ScalingDemo> {
+  final _anchor = LeaderLink();
+  final _boundsKey = GlobalKey();
+
+  late final _viewportBoundary = WidgetFollowerBoundary(_boundsKey);
+  late final _aligner = CupertinoPopoverToolbarAligner(_boundsKey);
+  late final _focalPoint = LeaderMenuFocalPoint(link: _anchor);
+
+  double _scale = 1.0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      height: double.infinity,
+      color: const Color(0xFF222222),
+      child: Stack(
+        children: [
+          Positioned.fill(
+            child: Transform.scale(
+              scale: _scale,
+              child: BuildInOrder(
+                children: [
+                  Center(
+                    child: Leader(
+                      link: _anchor,
+                      child: Container(width: 25, height: 25, color: Colors.red),
+                    ),
+                  ),
+                  Follower.withAligner(
+                    link: _anchor,
+                    aligner: _aligner,
+                    boundary: _viewportBoundary,
+                    repaintWhenLeaderChanges: true,
+                    child: CupertinoPopoverToolbar(
+                      focalPoint: _focalPoint,
+                      children: [
+                        TextButton(
+                          // ignore: avoid_print
+                          onPressed: () => print("one"),
+                          child: const Text("One", style: TextStyle(color: Colors.white)),
+                        ),
+                        TextButton(
+                          // ignore: avoid_print
+                          onPressed: () => print("two"),
+                          child: const Text("Two", style: TextStyle(color: Colors.white)),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          Positioned.fill(
+            child: Align(
+              alignment: const Alignment(0.0, 0.95),
+              child: SizedBox(
+                width: 200,
+                child: IntrinsicHeight(
+                  child: Slider(
+                    value: _scale,
+                    min: 0.1,
+                    max: 5.0,
+                    onChanged: (newValue) {
+                      setState(() {
+                        _scale = newValue;
+                      });
+                    },
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:example/demo_hover.dart';
 import 'package:example/demo_kitchen_sink.dart';
+import 'package:example/demo_scaling.dart';
 import 'package:example/demo_scrollables.dart';
 import 'package:flutter/material.dart';
 import 'package:follow_the_leader/follow_the_leader.dart';
@@ -106,6 +107,10 @@ final _items = [
   _MenuItem(
     title: 'Orbiting Circles',
     pageBuilder: (context) => const OrbitingCirclesDemo(),
+  ),
+  _MenuItem(
+    title: 'Scaling',
+    pageBuilder: (context) => const ScalingDemo(),
   ),
   _MenuItem(
     title: 'Scrollables',

--- a/lib/src/leader.dart
+++ b/lib/src/leader.dart
@@ -146,17 +146,21 @@ class RenderLeader extends RenderProxyBox {
   @override
   void paint(PaintingContext context, Offset offset) {
     final globalOffset = localToGlobal(Offset.zero);
-    FtlLogs.leader.finer("Painting Leader - $hashCode - offset: $offset - global offset: $globalOffset");
-    link.offset = globalOffset;
+    final scale = (localToGlobal(const Offset(1, 0)) - localToGlobal(Offset.zero)).dx;
+    FtlLogs.leader
+        .finer("Painting Leader - $hashCode - offset: $offset - global offset: $globalOffset - scale: $scale");
+    link
+      ..offset = globalOffset
+      ..scale = scale;
     if (layer == null) {
-      layer = LeaderLayer(link: link, offset: offset); // - Offset(0, offset.dy));
+      layer = LeaderLayer(link: link, offset: offset);
     } else {
       final LeaderLayer leaderLayer = layer! as LeaderLayer;
       leaderLayer
         ..link = link
-        ..offset = offset; // - Offset(0, offset.dy);
+        ..offset = offset;
     }
-    context.pushLayer(layer!, super.paint, Offset.zero); //offset - globalOffset);
+    context.pushLayer(layer!, super.paint, Offset.zero);
     assert(layer != null);
   }
 

--- a/lib/src/leader_link.dart
+++ b/lib/src/leader_link.dart
@@ -32,6 +32,18 @@ class LeaderLink with ChangeNotifier {
     notifyListeners();
   }
 
+  /// The current scale of the [Leader].
+  double? get scale => _scale;
+  double? _scale;
+  set scale(double? newScale) {
+    if (newScale == _scale) {
+      return;
+    }
+
+    _scale = newScale;
+    notifyListeners();
+  }
+
   /// The total size of the content of the connected [LeaderLayer].
   ///
   /// Generally this should be set by the [RenderObject] that paints on the
@@ -47,6 +59,14 @@ class LeaderLink with ChangeNotifier {
 
     _leaderSize = newSize;
     notifyListeners();
+  }
+
+  Offset? getOffsetInLeader(Alignment alignment) {
+    if (_offset == null || _leaderSize == null) {
+      return null;
+    }
+
+    return _offset! + alignment.alongSize(_leaderSize!);
   }
 
   bool get hasFollowers => _connectedFollowers > 0;


### PR DESCRIPTION
Add 'scale' to LeaderLink so that clients can fully account for transform (Resolves #21)

After adding the `scale` property, I added the ability to get a global offset within the `Leader` by calling a new method called `LeaderLink.getOffsetInLeader()`. Technically, that method eliminates our current need for `scale` info, but I suppose `scale` might be relevant in the future.

I filed #21 because we were seeing scaling tap area problems in a proprietary app. As far as I can, `follow_the_leader` works as expected. This PR adds a demo that proves it. I'll look deeper into the proprietary app to see if there's a problem over htere.