### PR TITLE
Schedule a frame after markNeedsPaint is called

### DIFF
--- a/lib/src/follower.dart
+++ b/lib/src/follower.dart
@@ -591,8 +591,11 @@ class RenderFollower extends RenderProxyBox {
   void markNeedsPaint() {
     super.markNeedsPaint();
 
-    // Immediately schedule a new frame to avoid being in a dirty in the cases
-    // where markNeedsPaint and there are no other frames scheduled.
+    // markNeedsPaint is called whenever the LeaderLink we are attached to changes its transform.
+    // It could happen during a build/layout/paint pipeline with no other frames scheduled,
+    // leaving us in a dirty state.
+    //
+    // Immediately schedule a new frame to avoid that.
     WidgetsBinding.instance.scheduleFrame();
   }
 

--- a/lib/src/follower.dart
+++ b/lib/src/follower.dart
@@ -4,7 +4,6 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' hide LeaderLayer;
-import 'package:flutter/scheduler.dart';
 import 'package:follow_the_leader/src/logging.dart';
 import 'package:vector_math/vector_math_64.dart' hide Colors;
 


### PR DESCRIPTION
Schedule a frame after markNeedsPaint is called

Currently, we are calling `markNeedsPaint` directly when the follower layer transform changes.

This is causing some `super_editor` golden tests to fail due to a crash in the `captureImage` method called by `matchesGoldenFile`. This is the test failure output:

```console
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
The following assertion was thrown running a test:
'package:flutter_test/src/_matchers_io.dart': Failed assertion: line 29 pos 10:
'!renderObject.debugNeedsPaint': is not true.

When the exception was thrown, this was the stack:
#2      captureImage (package:flutter_test/src/_matchers_io.dart:29:10)
#3      MatchesGoldenFile.matchAsync (package:flutter_test/src/_matchers_io.dart:96:21)
#4      MatchesGoldenFileWithPixelAllowance.matchAsync (file:///var/super_editor/super_editor/test_goldens/test_tools_goldens.dart:164:26)
#5      _expect (package:matcher/src/expect/expect.dart:109:26)
#6      expectLater (package:matcher/src/expect/expect.dart:73:5)
#7      expectLater (package:flutter_test/src/widget_tester.dart:495:25)
#8      _testParagraphSelection.<anonymous closure> (file:///var/super_editor/super_editor/test_goldens/editor/mobile/mobile_selection_test.dart:833:11)
<asynchronous suspension>
#9      testGoldensOnAndroid.<anonymous closure> (file:///var/super_editor/super_editor/test_goldens/test_tools_goldens.dart:20:7)
<asynchronous suspension>
#10     testGoldens.<anonymous closure>.body (package:golden_toolkit/src/testing_tools.dart:167:11)
<asynchronous suspension>
#11     testGoldens.<anonymous closure> (package:golden_toolkit/src/testing_tools.dart:177:9)
<asynchronous suspension>
#12     testWidgets.<anonymous closure>.<anonymous closure> (package:flutter_test/src/widget_tester.dart:168:15)
<asynchronous suspension>
#13     TestWidgetsFlutterBinding._runTestBody (package:flutter_test/src/binding.dart:1013:5)
<asynchronous suspension>
<asynchronous suspension>
(elided 3 frames from class _AssertionError and package:stack_trace)

The test description was:
  single tap text (on Android)
════════════════════════════════════════════════════════════════════════════════════════════════════
00:01 +0 -5: SuperEditor mobile selection Android single tap text (on Android) [E]                                                                                                                                                                                                                                      
  Test failed. See exception logs above.
  The test description was: single tap text (on Android)
```

This is the method that causes the crash:

```dart
Future<ui.Image> captureImage(Element element) {
  assert(element.renderObject != null);
  RenderObject renderObject = element.renderObject!;
  while (!renderObject.isRepaintBoundary) {
    renderObject = renderObject.parent!;
  }
  assert(!renderObject.debugNeedsPaint);  // crashes here
  final OffsetLayer layer = renderObject.debugLayer! as OffsetLayer;
  return layer.toImage(renderObject.paintBounds);
}
```

An example of a failing test: 

```dart
testGoldensOnAndroid("with caret change colors", (tester) async {
    final testContext = await tester //
        .createDocument() //
        .fromMarkdown("This is some text to select.") //
        .useAppTheme(ThemeData(primaryColor: Colors.red)) //
        .pump();
    final nodeId = testContext.findEditContext().document.nodes.first.id;

    await tester.placeCaretInParagraph(nodeId, 15);

    await expectLater(
      find.byType(MaterialApp),
      matchesGoldenFile("goldens/supereditor_android_collapsed_handle_color.png"),
    );
  });
```

As an experiment, I tried to add `await tester.pumpAndSettle();` in the test before the `expectLater`, but the exception  still happens.

For some reason, the crash doesn't happen on mac.

This PR overrides `markNeedsPaint` to schedule a new frame.