### PR TITLE
Fix dirty paint state in golden tests

### DIFF
--- a/lib/src/follower.dart
+++ b/lib/src/follower.dart
@@ -610,7 +610,6 @@ class RenderFollower extends RenderProxyBox {
 
     if (kDebugMode &&
         !kIsWeb &&
-        Platform.isLinux &&
         Platform.environment.containsKey('FLUTTER_TEST') &&
         !WidgetsBinding.instance.hasScheduledFrame) {
       // We are running on a linux test and we don't have a scheduled frame.


### PR DESCRIPTION
Fix dirty paint stat in golden tests

The same issue that happened in https://github.com/Flutter-Bounty-Hunters/follow_the_leader/issues/41 now is happening in super_editor in some Android golden tests:

```console
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
The following assertion was thrown running a test:
'package:flutter_test/src/_matchers_io.dart': Failed assertion: line 29 pos 10:
'!renderObject.debugNeedsPaint': is not true.

When the exception was thrown, this was the stack:
#2      captureImage (package:flutter_test/src/_matchers_io.dart:29:10)
#3      MatchesGoldenFile.matchAsync (package:flutter_test/src/_matchers_io.dart:96:21)
#4      _expect (package:matcher/src/expect/expect.dart:109:26)
#5      expectLater (package:matcher/src/expect/expect.dart:73:5)
#6      expectLater (package:flutter_test/src/widget_tester.dart:511:25)
#7      compareWithGolden (package:golden_toolkit/src/testing_tools.dart:296:9)
```

This is a test only issue.

To fix that, this PR changes the workaround added in https://github.com/Flutter-Bounty-Hunters/follow_the_leader/pull/40 to run on all platforms.