### PR TITLE
Make follower gap use dip instead of px

### DIFF
--- a/lib/src/follower.dart
+++ b/lib/src/follower.dart
@@ -471,7 +471,7 @@ class RenderFollower extends RenderProxyBox {
   @override
   bool hitTestChildren(BoxHitTestResult result, {required Offset position}) {
     final followerOffset = _followerOffsetFromLeader ?? Offset.zero;
-    final transform = layer?.getLastTransform()?..translate(followerOffset.dx, followerOffset.dy);
+    final transform = layer?.getLastTransform()?..translateByDouble(followerOffset.dx, followerOffset.dy, 0, 0);
 
     return result.addWithPaintTransform(
       transform: transform,
@@ -794,7 +794,7 @@ class RenderFollower extends RenderProxyBox {
     final transform = layer?.getLastTransform() ?? Matrix4.identity();
 
     if (_followerOffsetFromLeader != null) {
-      transform.translate(_followerOffsetFromLeader!.dx, _followerOffsetFromLeader!.dy);
+      transform.translateByDouble(_followerOffsetFromLeader!.dx, _followerOffsetFromLeader!.dy, 0, 0);
     }
 
     return transform;
@@ -1155,22 +1155,23 @@ class FollowerLayer extends ContainerLayer {
     final focalPointToScreenTransform = screenToLeaderTransform
       // Scale from leader-space to screen-space. After the scale, the
       // origin will sit at the top-left corner of the leader, in screen-space.
-      ..scale(1 / leaderScale) // <- inverted because we want to undo the Leader scale
+      ..scaleByDouble(1 / leaderScale, 0, 0, 0) // <- inverted because we want to undo the Leader scale
       // Move the origin to the point on the Leader where we want to anchor
       // the Follower. This offset is in screen-space.
-      ..translate(anchorMetrics.leaderAnchorInScreenSpace.dx, anchorMetrics.leaderAnchorInScreenSpace.dy)
+      ..translateByDouble(anchorMetrics.leaderAnchorInScreenSpace.dx, anchorMetrics.leaderAnchorInScreenSpace.dy, 0, 0)
       // Move the origin away from the Leader in the direction of the desired gap, which
       // adds space between the Leader and the Follower.
-      ..translate(anchorMetrics.followerGapInScreenSpace.dx, anchorMetrics.followerGapInScreenSpace.dy)
+      ..translateByDouble(anchorMetrics.followerGapInScreenSpace.dx, anchorMetrics.followerGapInScreenSpace.dy, 0, 0)
       // Move the origin such that when the Follower is painted, the
       // Follower's desired anchor point (bottom-center, top-center, etc)
       // sits at the gap point that we moved to above.
-      ..translate(anchorMetrics.followerAnchorInFollowerSpace.dx, anchorMetrics.followerAnchorInFollowerSpace.dy)
+      ..translateByDouble(
+          anchorMetrics.followerAnchorInFollowerSpace.dx, anchorMetrics.followerAnchorInFollowerSpace.dy, 0, 0)
       // Scale from screen-space to follower-space. After this scale, the
       // origin remains in the same place, sitting a gap distance from the
       // Leader, but all further translations will be scaled based on the
       // the Follower's scale.
-      ..scale(followerScale);
+      ..scaleByDouble(followerScale, 0, 0, 0);
 
     _lastTransform = focalPointToScreenTransform;
 
@@ -1244,7 +1245,7 @@ class FollowerLayer extends ContainerLayer {
       return;
     }
 
-    desiredTransform.translate(followerAdjustment.dx, followerAdjustment.dy);
+    desiredTransform.translateByDouble(followerAdjustment.dx, followerAdjustment.dy, 0, 0);
   }
 
   /// Builds and returns a transform that goes from a layer-space to

--- a/lib/src/follower.dart
+++ b/lib/src/follower.dart
@@ -471,7 +471,7 @@ class RenderFollower extends RenderProxyBox {
   @override
   bool hitTestChildren(BoxHitTestResult result, {required Offset position}) {
     final followerOffset = _followerOffsetFromLeader ?? Offset.zero;
-    final transform = layer?.getLastTransform()?..translateByDouble(followerOffset.dx, followerOffset.dy, 0, 0);
+    final transform = layer?.getLastTransform()?..translateByDouble(followerOffset.dx, followerOffset.dy, 0, 1.0);
 
     return result.addWithPaintTransform(
       transform: transform,
@@ -794,7 +794,7 @@ class RenderFollower extends RenderProxyBox {
     final transform = layer?.getLastTransform() ?? Matrix4.identity();
 
     if (_followerOffsetFromLeader != null) {
-      transform.translateByDouble(_followerOffsetFromLeader!.dx, _followerOffsetFromLeader!.dy, 0, 0);
+      transform.translateByDouble(_followerOffsetFromLeader!.dx, _followerOffsetFromLeader!.dy, 0, 1.0);
     }
 
     return transform;
@@ -1155,23 +1155,25 @@ class FollowerLayer extends ContainerLayer {
     final focalPointToScreenTransform = screenToLeaderTransform
       // Scale from leader-space to screen-space. After the scale, the
       // origin will sit at the top-left corner of the leader, in screen-space.
-      ..scaleByDouble(1 / leaderScale, 0, 0, 0) // <- inverted because we want to undo the Leader scale
+      ..scaleByDouble(1 / leaderScale, 1 / leaderScale, 1 / leaderScale,
+          1.0) // <- inverted because we want to undo the Leader scale
       // Move the origin to the point on the Leader where we want to anchor
       // the Follower. This offset is in screen-space.
-      ..translateByDouble(anchorMetrics.leaderAnchorInScreenSpace.dx, anchorMetrics.leaderAnchorInScreenSpace.dy, 0, 0)
+      ..translateByDouble(
+          anchorMetrics.leaderAnchorInScreenSpace.dx, anchorMetrics.leaderAnchorInScreenSpace.dy, 0, 1.0)
       // Move the origin away from the Leader in the direction of the desired gap, which
       // adds space between the Leader and the Follower.
-      ..translateByDouble(anchorMetrics.followerGapInScreenSpace.dx, anchorMetrics.followerGapInScreenSpace.dy, 0, 0)
+      ..translateByDouble(anchorMetrics.followerGapInScreenSpace.dx, anchorMetrics.followerGapInScreenSpace.dy, 0, 1.0)
       // Move the origin such that when the Follower is painted, the
       // Follower's desired anchor point (bottom-center, top-center, etc)
       // sits at the gap point that we moved to above.
       ..translateByDouble(
-          anchorMetrics.followerAnchorInFollowerSpace.dx, anchorMetrics.followerAnchorInFollowerSpace.dy, 0, 0)
+          anchorMetrics.followerAnchorInFollowerSpace.dx, anchorMetrics.followerAnchorInFollowerSpace.dy, 0, 1.0)
       // Scale from screen-space to follower-space. After this scale, the
       // origin remains in the same place, sitting a gap distance from the
       // Leader, but all further translations will be scaled based on the
       // the Follower's scale.
-      ..scaleByDouble(followerScale, 0, 0, 0);
+      ..scaleByDouble(followerScale, followerScale, followerScale, 1.0);
 
     _lastTransform = focalPointToScreenTransform;
 
@@ -1245,7 +1247,7 @@ class FollowerLayer extends ContainerLayer {
       return;
     }
 
-    desiredTransform.translateByDouble(followerAdjustment.dx, followerAdjustment.dy, 0, 0);
+    desiredTransform.translateByDouble(followerAdjustment.dx, followerAdjustment.dy, 0, 1.0);
   }
 
   /// Builds and returns a transform that goes from a layer-space to

--- a/lib/src/follower.dart
+++ b/lib/src/follower.dart
@@ -1210,7 +1210,7 @@ class FollowerLayer extends ContainerLayer {
 
     return _AnchorMetrics(
       leaderAnchorInScreenSpace: alignment.leaderAnchor.alongSize(leaderSize * leaderScale),
-      followerGapInScreenSpace: alignment.followerOffset.toPixels(leaderScale),
+      followerGapInScreenSpace: alignment.followerOffset,
       followerAnchorInFollowerSpace: -alignment.followerAnchor.alongSize(followerSize * followerScale),
     );
   }

--- a/lib/src/leader.dart
+++ b/lib/src/leader.dart
@@ -310,7 +310,7 @@ class LeaderLayer extends ContainerLayer {
   void applyTransform(Layer? child, Matrix4 transform) {
     assert(_lastOffset != null);
     if (_lastOffset != Offset.zero) {
-      transform.translate(_lastOffset!.dx, _lastOffset!.dy);
+      transform.translateByDouble(_lastOffset!.dx, _lastOffset!.dy, 0, 0);
     }
   }
 

--- a/lib/src/leader.dart
+++ b/lib/src/leader.dart
@@ -310,7 +310,7 @@ class LeaderLayer extends ContainerLayer {
   void applyTransform(Layer? child, Matrix4 transform) {
     assert(_lastOffset != null);
     if (_lastOffset != Offset.zero) {
-      transform.translateByDouble(_lastOffset!.dx, _lastOffset!.dy, 0, 0);
+      transform.translateByDouble(_lastOffset!.dx, _lastOffset!.dy, 0, 1.0);
     }
   }
 


### PR DESCRIPTION
Make follower gap use dip instead of px

When upgrading the follow_the_leader dependency on super_editor I noticed the magnifier is being displayed way of from where it should be.

The gap between the leader and the follower is being converted to physical pixels, and it seems that it should be in dip instead.