### PR TITLE
chore: update vector_math dependency for compatibility with latest fo…

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
 
   logging: ^1.0.1
   super_keyboard: ^0.2.2
-  vector_math: ^2.1.2
+  vector_math: ^2.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR updates the vector_math dependency version to align with the changes introduced in commit [aca5018](https://github.com/Flutter-Bounty-Hunters/follow_the_leader/commit/aca5018edf6177c010df804286690c29449110bc)

Without this update, builds fail with the following error:
Error: The method 'translateByDouble' isn't defined for the class 'Matrix4'.

This occurs because the changes in that commit rely on methods available only in the latest versions of vector_math.